### PR TITLE
fixed own-downgradeable bug

### DIFF
--- a/ami-journal/resources/views/pages/usermanagement/index.blade.php
+++ b/ami-journal/resources/views/pages/usermanagement/index.blade.php
@@ -45,13 +45,17 @@
             <form method="POST" action="{{ route('usermanagement.update') }}">
                 <input type="hidden" name="user" value="{{$user->id}}">
                 @csrf
-                <button type="submit" class="action-button">
-                    @if($user->accepted_reviewer)
-                        Withdraw
-                    @else
-                        Promote
+                @auth
+                    @if(Auth::user()->id !== $user->id)
+                        <button type="submit" class="action-button">
+                            @if($user->accepted_reviewer)
+                                Withdraw
+                            @else
+                                Promote
+                            @endif
+                        </button>
                     @endif
-                </button>
+                @endauth
             </form>
         </div>
     </div>


### PR DESCRIPTION
The user (who logged in, and rewiever) can't do  self-downgrade (issue title). However, the database has no column for admin status, so other reviewer can downgrade the site admin (issue description)